### PR TITLE
Fix grunt task doesnt allow followed tasks to execute

### DIFF
--- a/tasks/css-bundler.js
+++ b/tasks/css-bundler.js
@@ -17,6 +17,6 @@ module.exports = function(grunt) {
         });
       });
     });
-    batch.end(this.async());
+    batch.end(this.async()());
   });
 };


### PR DESCRIPTION
this.async() returns 'done' function.